### PR TITLE
static_views: don't use oversized_array

### DIFF
--- a/include/lefticus/tools/static_views.hpp
+++ b/include/lefticus/tools/static_views.hpp
@@ -1,6 +1,7 @@
 #ifndef LEFTICUS_TOOLS_STATIC_VIEWS_HPP
 #define LEFTICUS_TOOLS_STATIC_VIEWS_HPP
 
+#include <algorithm>
 #include <array>
 #include <span>
 #include <string_view>

--- a/include/lefticus/tools/static_views.hpp
+++ b/include/lefticus/tools/static_views.hpp
@@ -1,15 +1,11 @@
 #ifndef LEFTICUS_TOOLS_STATIC_VIEWS_HPP
 #define LEFTICUS_TOOLS_STATIC_VIEWS_HPP
 
-#include <algorithm>
 #include <array>
 #include <span>
 #include <string_view>
 
 namespace lefticus::tools {
-
-// max size object we can convert
-static constexpr std::size_t oversized_size = 10 * 1024;
 
 
 template<typename Value>
@@ -34,33 +30,12 @@ concept creates_string_like = requires(const Callable &callable)
   typename std::decay_t<decltype(callable())>::traits_type;
 };
 
-
-template<typename Value> struct oversized_array
-{
-  std::array<Value, oversized_size> data{};
-  std::size_t size{};
-
-  using value_type = Value;
-
-  constexpr auto begin() const noexcept { return data.begin(); }
-  constexpr auto end() const noexcept { return std::next(data.begin(), static_cast<std::ptrdiff_t>(size)); }
-};
-
-template<typename Data> constexpr auto to_oversized_array(const Data &str)
-{
-  oversized_array<typename Data::value_type> result;
-  std::copy(str.begin(), str.end(), result.data.begin());
-  result.size = str.size();
-  return result;
-}
-
 consteval auto to_right_sized_array(creates_iterable auto callable)
 {
-  constexpr auto oversized = to_oversized_array(callable());
-
-  using Value_Type = typename std::decay_t<decltype(oversized)>::value_type;
-  std::array<Value_Type, oversized.size> result;
-  std::copy(oversized.begin(), oversized.end(), result.begin());
+  const auto tmp = callable();
+  using Value_Type = typename std::decay_t<decltype(tmp)>::value_type;
+  std::array<Value_Type, callable().size()> result;
+  std::copy(tmp.begin(), tmp.end(), result.begin());
   return result;
 }
 


### PR DESCRIPTION
Instead, directly create a std::array of the proper size callable is now called twice, but it's fine because the second time is as part of a template argument.
Also, both calls are in a consteval function, so this is "free"