### PR TITLE
fix: add missing `#include <iterator>`

### DIFF
--- a/include/lefticus/tools/flat_map_adapter.hpp
+++ b/include/lefticus/tools/flat_map_adapter.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <initializer_list>
+#include <iterator>
 #include <stdexcept>
 #include <utility>
 


### PR DESCRIPTION
Found while compiling with Clang modules:
```
In file included from /home/johel/tmp/Waarudo_builds/ClangRelease/lefticus-tools-prefix/src/lefticus-tools/include/lefticus/tools/static_views.hpp:4:
In file included from /home/johel/tmp/Waarudo_builds/ClangRelease/lefticus-tools-prefix/src/lefticus-tools/include/lefticus/tools/simple_stack_flat_map.hpp:4:
/home/johel/tmp/Waarudo_builds/ClangRelease/lefticus-tools-prefix/src/lefticus-tools/include/lefticus/tools/flat_map_adapter.hpp:114:19: error: declaration of 'next' must be imported from module 'std.iterator.__iterator.next' before it is required
    return { std::next(data.begin(), static_cast<difference_type>(data.size() - 1)), true };
                  ^
/home/johel/root/clang/bin/../include/c++/v1/__iterator/next.h:30:5: note: declaration here is not visible
    next(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1) {
    ^
```