### PR TITLE
Fix erroneous IntelliSesense E0292 for int_np::value

### DIFF
--- a/include/lefticus/tools/non_promoting_ints.hpp
+++ b/include/lefticus/tools/non_promoting_ints.hpp
@@ -5,6 +5,9 @@
 #include <concepts>
 #include <cstdint>
 
+#ifdef __INTELLISENSE__
+  #pragma diag_suppress 349
+#endif
 
 namespace lefticus::tools {
 template<std::integral Type> struct int_np

--- a/include/lefticus/tools/non_promoting_ints.hpp
+++ b/include/lefticus/tools/non_promoting_ints.hpp
@@ -11,6 +11,10 @@ template<std::integral Type> struct int_np
 {
   using value_type = Type;
 
+private:
+  value_type value;
+
+public:
   // if it's the proper type, make it easy to convert
   // cppcheck-suppress noExplicitConstructor
   constexpr int_np(value_type value_) noexcept : value{ value_ } {}
@@ -199,9 +203,6 @@ template<std::integral Type> struct int_np
   }
 
   friend constexpr auto operator<=>(const int_np &, const int_np &) = default;
-
-private:
-  value_type value;
 };
 
 using uint_np8_t = int_np<std::uint8_t>;


### PR DESCRIPTION
Moves declaration of int_np::value to the top of the struct to silence an erroneous E0292 error ("value" is not a nonstatic data member or base class of class "lefticus::tools::int_np<uint8_t>") being reported by IntelliSesense.